### PR TITLE
Use vendor-neutral extension for barycentric coordinates

### DIFF
--- a/src/rocky/vsg/DisplayManager.cpp
+++ b/src/rocky/vsg/DisplayManager.cpp
@@ -210,7 +210,7 @@ DisplayManager::addWindow(vsg::ref_ptr<vsg::WindowTraits> traits)
     {
         traits->deviceFeatures = vsg::DeviceFeatures::create();
     }
-    traits->deviceExtensionNames.push_back(VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
+    traits->deviceExtensionNames.push_back(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
     auto& bary = traits->deviceFeatures->get<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR>();
     bary.fragmentShaderBarycentric = true;
 

--- a/src/rocky/vsg/shaders/rocky.icon.frag
+++ b/src/rocky/vsg/shaders/rocky.icon.frag
@@ -1,5 +1,4 @@
 #version 450
-#extension GL_NV_fragment_shader_barycentric : enable
 
 // uniforms
 layout(set = 0, binding = 2) uniform sampler2D icon_texture;

--- a/src/rocky/vsg/shaders/rocky.mesh.frag
+++ b/src/rocky/vsg/shaders/rocky.mesh.frag
@@ -1,5 +1,5 @@
 #version 450
-#extension GL_NV_fragment_shader_barycentric : enable
+#extension GL_EXT_fragment_shader_barycentric : enable
 #pragma import_defines(USE_MESH_TEXTURE)
 
 layout(location = 1) in vec2 uv;
@@ -30,7 +30,7 @@ void main()
 
     if (vary.wireframe > 0.0)
     {
-        float b = min(gl_BaryCoordNV.x, min(gl_BaryCoordNV.y, gl_BaryCoordNV.z)) * vary.wireframe;
+        float b = min(gl_BaryCoordEXT.x, min(gl_BaryCoordEXT.y, gl_BaryCoordEXT.z)) * vary.wireframe;
         out_color.rgb = mix(vec3(1, 1, 1), out_color.rgb, clamp(b, 0.85, 1.0));
     }
 }

--- a/src/rocky/vsg/shaders/rocky.terrain.frag
+++ b/src/rocky/vsg/shaders/rocky.terrain.frag
@@ -1,5 +1,5 @@
 #version 450
-#extension GL_NV_fragment_shader_barycentric : enable
+#extension GL_EXT_fragment_shader_barycentric : enable
 #pragma import_defines(RK_LIGHTING)
 #pragma import_defines(RK_WIREFRAME_OVERLAY)
 
@@ -52,9 +52,9 @@ void main()
     apply_lighting(out_color, rk.vertex_view, get_normal());
 #endif
 
-#if defined(RK_WIREFRAME_OVERLAY) && defined(GL_NV_fragment_shader_barycentric)
+#if defined(RK_WIREFRAME_OVERLAY) && defined(GL_EXT_fragment_shader_barycentric)
     // outlines - debugging
-    float b = min(gl_BaryCoordNV.x, min(gl_BaryCoordNV.y, gl_BaryCoordNV.z))*32.0;
+    float b = min(gl_BaryCoordEXT.x, min(gl_BaryCoordEXT.y, gl_BaryCoordEXT.z))*32.0;
     out_color.rgb = mix(vec3(1,1,1), out_color.rgb, clamp(b,0.85,1.0));
 #endif
 }


### PR DESCRIPTION
Otherwise it only runs on Nvidia hardware, despite there being no good reason to only run on Nvidia hardware.